### PR TITLE
Fix build on non x86_64 (NOOPT)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "skip-icons-check": true,
-    "only-arches": ["x86_64"]
+    "skip-icons-check": true
 }

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.TAP.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.TAP.json
@@ -21,10 +21,22 @@
             "build-options": {
                 "env": {
                     "CFLAGS": "`pkg-config --cflags lv2`"
+                },
+                "arch": {
+                    "aarch64": {
+                        "env":{
+                            "NOOPT": "true"
+                        }
+                    },
+                    "arm": {
+                        "env": {
+                            "NOOPT": "true"
+                        }
+                    }
                 }
             },
             "build-commands": [
-                "make",
+                "make NOOPT=${NOOPT}",
                 "make install INSTALL_PATH=/app/extensions/Lv2Plugins/TAP/lv2"
             ],
             "post-install": [


### PR DESCRIPTION
Enable on non x86_64

See https://github.com/moddevices/tap-lv2/issues/7#issuecomment-649981615